### PR TITLE
Include .d.ts and source map in `files`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "types": "lib/index.d.ts",
     "files": [
         "lib/index.js",
+        "lib/index.js.map",
         "lib/*.d.ts"
     ],
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "main": "lib/index.js",
     "types": "lib/index.d.ts",
     "files": [
-        "lib/index.js"
+        "lib/index.js",
+        "lib/*.d.ts"
     ],
     "scripts": {
         "prepublishOnly": "npm run release",


### PR DESCRIPTION
pnpm @ 9 respects the `files` directive in `package.json` so a new install is missing the type definitions. Also include the source map, however this references /src/*.tsx files, so i still get:

```
Failed to parse source map from '/Users/sdf/ESRF/daiquiri/daiquiri-ui.git/node_modules/.pnpm/rc-knob@https+++codeload.github.com+stufisher+rc-knob+tar.gz+66ec11c9b4f474e275bd0894cdf78d05_m4ywyvrpds6cryf4txp663llw4/node_modules/rc-knob/src/utils.ts' file: Error: ENOENT: no such file or directory, open '/Users/sdf/ESRF/daiquiri/daiquiri-ui.git/node_modules/.pnpm/rc-knob@https+++codeload.github.com+stufisher+rc-knob+tar.gz+66ec11c9b4f474e275bd0894cdf78d05_m4ywyvrpds6cryf4txp663llw4/node_modules/rc-knob/src/utils.ts'
```

Do we include all of /src/ in `files` too?