### PR TITLE
doc: Fixed ref

### DIFF
--- a/docusaurus/docs/1_base_components/3_scale.mdx
+++ b/docusaurus/docs/1_base_components/3_scale.mdx
@@ -124,7 +124,7 @@ Most of them are just passed down from the `Pointer` or the `Knob`.
 
 Additional are:
 
--   `center`, the half of the [`size`](#size) of the [`Knob`](#Knob)
+-   `center`, the half of the `size` of the `Knob`
 -   `stepSize`, the size of the angle of one step in degree
 -   `translateX`, `translateY` that are needed to put the tick on the correct
     position using the transform prop e.g:


### PR DESCRIPTION
Drop ref from the doc, which does not exist anymore in this page.